### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Pillar
 
 This is the latest iteration on the Attract project. We are building a unified
 framework called Pillar. Pillar will combine Blender Cloud and Attract. You
-can see Pillar in action on the [Blender Cloud](https://cloud.bender.org).
+can see Pillar in action on the [Blender Cloud](https://cloud.blender.org).
 
 ## Custom fonts
 


### PR DESCRIPTION
Blender cloud link is currently 'cloud.bender.org' and it points to a random German website, an added 'l' fixes the issue.